### PR TITLE
missing bracket in the example config file

### DIFF
--- a/example_matahn.cfg
+++ b/example_matahn.cfg
@@ -9,7 +9,7 @@ LASINFO_BINARY = '/usr/local/bin/lasinfo'
 LASMERGE_BINARY = '/usr/local/bin/lasmerge'
 
 CELERY_BROKER_URL='redis://localhost:6379/0',
-CELERY_RESULT_BACKEND='db+SQLALCHEMY_DATABASE_URI
+CELERY_RESULT_BACKEND='db+SQLALCHEMY_DATABASE_URI'
 
 SERVER_NAME = 'example.com'
 STATIC_DOWNLOAD_URL = '/static'


### PR DESCRIPTION
When I was setting up the config I was getting a strange error about EOL literals, it turns out it was just a missing bracket. Also there might be an additional comma on the line above.
